### PR TITLE
[FASAM-1132] Enable emergency lights when fire alarm triggered

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 # stockBot
 
 Tiny app to search for a new phone
+
+TEST!


### PR DESCRIPTION
**Reference ID:** FASAM-1132

**Reason for the change:** Emergency lights should turn on when someone triggers the fire alarm.

**Expected behaviour:** Emergency lights will turn on if the alarm is activated.

**Notes:** ...